### PR TITLE
fix: dead_letter_queue_create input

### DIFF
--- a/sqs.tf
+++ b/sqs.tf
@@ -18,6 +18,7 @@ module "dead_letter_queue" {
 }
 
 data "aws_iam_policy_document" "dead_letter_queue_access" {
+  count = var.dead_letter_queue_create ? 1 : 0
   statement {
     effect    = "Allow"
     actions   = ["sqs:SendMessage"]
@@ -30,5 +31,5 @@ resource "aws_iam_role_policy" "dead_letter_queue" {
 
   role   = aws_iam_role.default.name
   name   = "${module.iam_label.id}-dead-letter-queue"
-  policy = data.aws_iam_policy_document.dead_letter_queue_access.json
+  policy = data.aws_iam_policy_document.dead_letter_queue_access[0].json
 }


### PR DESCRIPTION
## Description
This change fixes dead_letter_queue_create input. Normally when it set false it should not create sqs but it was giving following error. So this pr aims to fix that.

```
│ Error: Invalid index
│
│   on .terraform/modules/xxx/sqs.tf line 24, in data "aws_iam_policy_document" "dead_letter_queue_access":
│   24:     resources = [module.dead_letter_queue[0].queue_arn]
│     ├────────────────
│     │ module.dead_letter_queue is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```
