### PR TITLE
fix: fixed vpc config iam role

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ Terraform module which creates a lambda function, monitoring via CloudWatch and 
 | [aws_cloudwatch_metric_alarm.throttles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.dead_letter_queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_iam_policy.lambda_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.dead_letter_queue_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.log_stream_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -64,23 +64,7 @@ resource "aws_iam_role" "default" {
   tags               = module.iam_label.tags
 }
 
-data "aws_iam_policy_document" "log_stream_access" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-    resources = [
-      "${aws_cloudwatch_log_group.default.arn}:*",
-      "arn:aws:logs:${module.this.aws_region}:${module.this.aws_account_id}:log-group:/aws/lambda-insights:*"
-    ]
-    effect = "Allow"
-  }
-}
-
-resource "aws_iam_role_policy" "logs" {
-  name = "${module.iam_label.id}-logs"
-
-  role   = aws_iam_role.default.id
-  policy = data.aws_iam_policy_document.log_stream_access.json
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = aws_iam_role.default.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }


### PR DESCRIPTION
## Description
In order to create vpc config we need additional roles for the iam that we create so this pr aims to implement that.

Btw I deleted other logs actions/roles because `AWSLambdaVPCAccessExecutionRole` already includes these stuff.